### PR TITLE
Add new field in CollectionStats Schema

### DIFF
--- a/magicpyden/schema.py
+++ b/magicpyden/schema.py
@@ -200,6 +200,7 @@ class CollectionActivities(BaseModel):
 
 
 class CollectionStats(Symbol):
+    avg_price_24hr: int = Field(..., alias="avgPrice24hr")
     floor_price: int = Field(..., alias="floorPrice")
     listed_count: int = Field(..., alias="listedCount")
     volume_all: int = Field(..., alias="volumeAll")


### PR DESCRIPTION
It seem's that avgPrice24hr is present on the api response, although its not documented on [https://api.magiceden.dev](https://api.magiceden.dev/#b9e7e094-eaa1-432c-9bb8-3c3d4da5fc78)
